### PR TITLE
chore: move FileAPI/blob to .js files

### DIFF
--- a/FileAPI/blob/Blob-constructor-dom.window.js
+++ b/FileAPI/blob/Blob-constructor-dom.window.js
@@ -1,0 +1,48 @@
+// META: title=Blob constructor
+// META: script=../support/Blob.js
+'use strict';
+
+test(function() {
+  var args = [
+    document.createElement("div"),
+    window,
+  ];
+  args.forEach(function(arg) {
+    assert_throws_js(TypeError, function() {
+      new Blob(arg);
+    }, "Should throw for argument " + format_value(arg) + ".");
+  });
+}, "Passing platform objects for blobParts should throw a TypeError.");
+
+test(function() {
+  var element = document.createElement("div");
+  element.appendChild(document.createElement("div"));
+  element.appendChild(document.createElement("p"));
+  var list = element.children;
+  Object.defineProperty(list, "length", {
+    get: function() { throw test_error; }
+  });
+  assert_throws_exactly(test_error, function() {
+    new Blob(list);
+  });
+}, "A platform object that supports indexed properties should be treated as a sequence for the blobParts argument (overwritten 'length'.)");
+
+test_blob(function() {
+  var select = document.createElement("select");
+  select.appendChild(document.createElement("option"));
+  return new Blob(select);
+}, {
+  expected: "[object HTMLOptionElement]",
+  type: "",
+  desc: "Passing an platform object that supports indexed properties as the blobParts array should work (select)."
+});
+
+test_blob(function() {
+  var elm = document.createElement("div");
+  elm.setAttribute("foo", "bar");
+  return new Blob(elm.attributes);
+}, {
+  expected: "[object Attr]",
+  type: "",
+  desc: "Passing an platform object that supports indexed properties as the blobParts array should work (attributes)."
+});

--- a/FileAPI/blob/Blob-constructor.any.js
+++ b/FileAPI/blob/Blob-constructor.any.js
@@ -1,17 +1,9 @@
-<!DOCTYPE html>
-<meta charset=utf-8>
-<title>Blob constructor</title>
-<link rel=help href="http://dev.w3.org/2006/webapi/FileAPI/#constructorBlob">
-<link rel=help href="https://heycam.github.io/webidl/#es-union">
-<link rel=help href="https://heycam.github.io/webidl/#es-dictionary">
-<link rel=help href="https://heycam.github.io/webidl/#es-sequence">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="../support/Blob.js"></script>
-<div id="log"></div>
-<script>
+// META: title=Blob constructor
+// META: script=../support/Blob.js
+'use strict';
+
 test(function() {
-  assert_true("Blob" in window, "window should have a Blob property.");
+  assert_true("Blob" in globalThis, "globalThis should have a Blob property.");
   assert_equals(Blob.length, 0, "Blob.length should be 0.");
   assert_true(Blob instanceof Function, "Blob should be a function.");
 }, "Blob interface object");
@@ -55,8 +47,6 @@ test(function() {
     new RegExp(),
     {},
     { 0: "FAIL", length: 1 },
-    document.createElement("div"),
-    window,
   ];
   args.forEach(function(arg) {
     assert_throws_js(TypeError, function() {
@@ -128,19 +118,6 @@ test(function() {
     new Blob(obj);
   });
 }, "The length getter should be invoked and any exceptions should be propagated.");
-
-test(function() {
-  var element = document.createElement("div");
-  element.appendChild(document.createElement("div"));
-  element.appendChild(document.createElement("p"));
-  var list = element.children;
-  Object.defineProperty(list, "length", {
-    get: function() { throw test_error; }
-  });
-  assert_throws_exactly(test_error, function() {
-    new Blob(list);
-  });
-}, "A platform object that supports indexed properties should be treated as a sequence for the blobParts argument (overwritten 'length'.)");
 
 test(function() {
   assert_throws_exactly(test_error, function() {
@@ -334,25 +311,7 @@ test_blob(function() {
   desc: "Passing a Float64Array as element of the blobParts array should work."
 });
 
-test_blob(function() {
-  var select = document.createElement("select");
-  select.appendChild(document.createElement("option"));
-  return new Blob(select);
-}, {
-  expected: "[object HTMLOptionElement]",
-  type: "",
-  desc: "Passing an platform object that supports indexed properties as the blobParts array should work (select)."
-});
 
-test_blob(function() {
-  var elm = document.createElement("div");
-  elm.setAttribute("foo", "bar");
-  return new Blob(elm.attributes);
-}, {
-  expected: "[object Attr]",
-  type: "",
-  desc: "Passing an platform object that supports indexed properties as the blobParts array should work (attributes)."
-});
 
 var t_ports = async_test("Passing a FrozenArray as the blobParts array should work (FrozenArray<MessagePort>).");
 t_ports.step(function() {
@@ -498,4 +457,3 @@ type_tests.forEach(function(t) {
     assert_equals(b.type, t[2]);
   }, "Blob with type " + format_value(t[1]));
 });
-</script>

--- a/FileAPI/blob/Blob-slice-overflow.any.js
+++ b/FileAPI/blob/Blob-slice-overflow.any.js
@@ -1,12 +1,5 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Blob slice overflow</title>
-<link rel="author" title="Intel" href="http://www.intel.com">
-<link rel="help" href="https://w3c.github.io/FileAPI/#dfn-slice">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<div id="log"></div>
-<script>
+// META: title=Blob slice overflow
+'use strict';
 
 var text = '';
 
@@ -37,6 +30,3 @@ test(function() {
   var sliceBlob = blob.slice(blob.size - 2, blob.size + 999);
   assert_equals(sliceBlob.size, 2, "Blob slice size");
 }, "slice end is greater than blob size, relativeEnd will be min(end, size)");
-
-</script>
-

--- a/FileAPI/blob/Blob-slice.any.js
+++ b/FileAPI/blob/Blob-slice.any.js
@@ -1,13 +1,7 @@
-<!DOCTYPE html>
-<meta charset=utf-8>
-<title>Blob slice</title>
-<link rel=help href="https://w3c.github.io/FileAPI/#slice-method-algo">
-<link rel=author title="Saurabh Anand" href="mailto:saurabhanandiit@gmail.com">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="../support/Blob.js"></script>
-<div id="log"></div>
-<script>
+// META: title=Blob slice
+// META: script=../support/Blob.js
+'use strict';
+
 test_blob(function() {
   var blobTemp = new Blob(["PASS"]);
   return blobTemp.slice();
@@ -235,4 +229,3 @@ validTypes.forEach(function(type) {
     desc: "Valid contentType (" + format_value(type) + ")"
   });
 });
-</script>


### PR DESCRIPTION
This moves Blob tests which do not need `document` to be in global scope to `.any.js` tests. Tests that require `document` are now `.window.js` tests.

This is done in an effort to allow [Deno](https://deno.land) to use these tests to validate it's implementation of `Blob`.
